### PR TITLE
[API] https for base url

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,1 +1,1 @@
-API_BASE_URL=http://pre-prod.jedisjeux.net
+API_BASE_URL=https://pre-prod.jedisjeux.net


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | kind of
| New feature?    | no
| Related tickets | 
| License         | MIT

www.jedisjeux.net is now with https base url, so we can use it, and it solves accessing to api problem.